### PR TITLE
Cria 'previous_pid' no json retornado pelo front

### DIFF
--- a/clea/regexes.py
+++ b/clea/regexes.py
@@ -128,6 +128,11 @@ BRANCH_REGEXES = {
             r"@(?:specific-use){e<=4}"
             r"=(?:scielo-v){e<=3}3(?:@[^/]*)?$"
         )),
+        ("previous_pid", "", bm_regex(
+            r"/(?:article-id){e<=2}(?:@[^/]*)?"
+            r"@(?:specific-use){e<=4}"
+            r"=(?:previous-pid)$"
+        )),
         ("article_title", "", bm_regex(
             r"/(?:article-title){e<=2}(?:@[^/]*)?$"
         )),

--- a/clea/regexes.py
+++ b/clea/regexes.py
@@ -133,6 +133,10 @@ BRANCH_REGEXES = {
             r"@(?:specific-use){e<=4}"
             r"=(?:previous-pid)$"
         )),
+        ("id_without_specified_use", "", bm_regex(
+            r"/(?:article-id){e<=2}(?:@[^/]*)?"
+            r"=(?:publisher-id){e<=4}(?:@[/]*)?$"
+        )),
         ("article_title", "", bm_regex(
             r"/(?:article-title){e<=2}(?:@[^/]*)?$"
         )),

--- a/tests/xml/Vkbh7CKQDNQzX7bW3cQVdJx.xml
+++ b/tests/xml/Vkbh7CKQDNQzX7bW3cQVdJx.xml
@@ -1,0 +1,11 @@
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.1 20151215//EN" "https://jats.nlm.nih.gov/publishing/1.1/JATS-journalpublishing1.dtd">
+<article xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mml="http://www.w3.org/1998/Math/MathML" dtd-version="3.0" article-type="research-article" xml:lang="en">
+  <front>
+    <article-meta>
+      <article-id pub-id-type="publisher-id" specific-use="scielo-v3">Vkbh7CKQDNQzX7bW3cQVdJx</article-id>
+      <article-id pub-id-type="publisher-id" specific-use="scielo-v2">S0037-86822013000100030</article-id>
+      <article-id pub-id-type="publisher-id" specific-use="previous-pid">S0037-86822012005000002</article-id>
+      <article-id pub-id-type="publisher-id">S0037-86822013000100007</article-id>
+      <article-id pub-id-type="doi">10.1590/S0037-86822012005000002</article-id>
+    </article-meta>
+</article>


### PR DESCRIPTION
#### O que esse PR faz?
Disponibilzar o previous-pid como previous_pid em article_meta.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando
`python -m clea -o output.json tests/xml/a.xml`

#### Algum cenário de contexto que queira dar?
necessário para o opac-airflow https://github.com/scieloorg/opac-airflow/blob/d09604d293fe16bbe756068003daa8e684e94bf5/airflow/dags/operations/sync_kernel_to_website_operations.py#L96

### Screenshots
n/a

#### Quais são tickets relevantes?
#6

### Referências
n/a